### PR TITLE
Implement exclude as a regular expression

### DIFF
--- a/lcov-to-cobertura-xml.py
+++ b/lcov-to-cobertura-xml.py
@@ -111,7 +111,11 @@ def generate_cobertura_xml(coverage_data, options):
 	packages = coverage_data['packages']
 	for package_name, package_data in packages.items():
 		# TODO: make more robust
-		if package_name in options.excludes:
+		skip = False
+		for exclude in options.excludes:
+			if re.match(exclude, package_name):
+				skip = True
+		if skip:
 			continue
 		package_element = document.createElement('package')
 		package_element.setAttribute('line-rate', package_data['line-rate'])


### PR DESCRIPTION
The documentation says that these can be regular expressions, but it
wasn't implemented that way. Now it is.
