### PR TITLE
Fix for handling of templatize code

### DIFF
--- a/lcov_cobertura/lcov_cobertura.py
+++ b/lcov_cobertura/lcov_cobertura.py
@@ -96,7 +96,7 @@ class LcovCobertura(object):
                     coverage_data['summary']['branches-total'] += file_branches_total
                     coverage_data['summary']['branches-covered'] += file_branches_covered
 
-            line_parts = line.split(':')
+            line_parts = line.split(':',1)
             input_type = line_parts[0]
 
             if input_type == 'SF':


### PR DESCRIPTION
Spaces from templatize code messes up the split so a maxsplit value of 1 is used to control
the splitting.
