### PR TITLE
Made a few minor changes to allow lcov_cobertura.py to be run as a console script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Coverage metrics supported:
  - Class/file overall line and branch coverage
  - Functions hit
  - Line and Branch hits
-
-## Quick command-line usage
+ 
+## Quick usage
 
 [Grab it raw](https://raw.github.com/eriwen/lcov-to-cobertura-xml/master/lcov_cobertura/lcov_cobertura.py) and run it with python:
 ```bash
@@ -28,15 +28,29 @@ python lcov_cobertura.py lcov-file.dat
 ```bash
 python lcov_cobertura.py lcov-file.dat --base-dir src/dir --excludes test.lib --output build/coverage.xml --demangle
 ```
-
-## Usage as a Python module
-
-You can install lcov_cobertura with [pip](http://pypi.python.org/pypi/pip):
+ 
+## With [pip](http://pypi.python.org/pypi/pip):
 ```bash
 pip install lcov_cobertura
 ```
 
-Then just use it anywhere in your python:
+### Command-line usage
+```bash
+lcov_cobertura lcov-file.dat
+```
+
+ - `-b/--base-dir` - (Optional) Directory where source files are located. Defaults to the current directory
+ - `-e/--excludes` - (Optional) Comma-separated list of regexes of packages to exclude
+ - `-o/--output` - (Optional) Path to store cobertura xml file. _Defaults to ./coverage.xml_
+ - `-d/--demangle` - (Optional) Demangle C++ function names. _Requires c++filt_
+
+```bash
+lcov_cobertura lcov-file.dat --base-dir src/dir --excludes test.lib --output build/coverage.xml --demangle
+```
+
+### Usage as a Python module
+
+Use it anywhere in your python:
 ```python
 from lcov_cobertura import LcovCobertura
 

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,8 @@ setup(name='lcov_cobertura',
                  'Topic :: Software Development :: Quality Assurance'
     ],
     keywords='lcov cobertura',
+    entry_points={
+        'console_scripts': ['lcov_cobertura=lcov_cobertura:main']
+    },
     license='Apache License, Version 2.0'
 )


### PR DESCRIPTION
For my use case, it makes things easier if I can run lcov_cobertura.py as a console script after installing with pip install: http://python-packaging.readthedocs.org/en/latest/command-line-scripts.html#the-console-scripts-entry-point. I figured other people might want to do this as well. I couldn't think of a way to write a unit test for this but I added an example to the Readme. 