### PR TITLE
Fixed issue with interior commas in function names.

### DIFF
--- a/lcov_cobertura/lcov_cobertura.py
+++ b/lcov_cobertura/lcov_cobertura.py
@@ -194,11 +194,11 @@ class LcovCobertura(object):
                 file_branches_covered = int(line_parts[1])
             elif input_type == 'FN':
                 # FN:5,(anonymous_1)
-                function_line, function_name = line_parts[-1].strip().split(',')
+                function_line, function_name = line_parts[-1].strip().split(',',1)
                 file_methods[function_name] = [function_line, '0']
             elif input_type == 'FNDA':
                 # FNDA:0,(anonymous_1)
-                (function_hits, function_name) = line_parts[-1].strip().split(',')
+                (function_hits, function_name) = line_parts[-1].strip().split(',',1)
                 if function_name not in file_methods:
                     file_methods[function_name] = ['0', '0']
                 file_methods[function_name][-1] = function_hits

--- a/test/test_lcov_cobertura.py
+++ b/test/test_lcov_cobertura.py
@@ -83,5 +83,16 @@ class Test(unittest.TestCase):
         self.assertEqual(result['packages']['foo']['lines-covered'], 1)
         self.assertEqual(result['packages']['foo']['lines-total'], 2)
 
+    def test_interior_commas_in_fn_parses(self):
+        converter = LcovCobertura(
+            'TN:\nSF:foo/file.ext\nDA:1,1\nDA:2,0\nFN:1,(anonymous_1<foo, bar>)\nFN:2,namedFn\nFNDA:1,(anonymous_1<foo, bar>)\nend_of_record\n')
+        result = converter.parse()
+        self.assertEqual(result['packages']['foo']['line-rate'], '0.5')
+        self.assertEqual(result['packages']['foo']['lines-covered'], 1)
+        self.assertEqual(result['packages']['foo']['lines-total'], 2)
+        self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['methods']['(anonymous_1<foo, bar>)'], ['1', '1'])
+        self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['methods']['namedFn'], ['2', '0'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Set maximum split parameter when breaking FN and FNDA values. With certain languages (Rust), demangled LCOV FN and FNDA entries can contain interior commas. This will result in more than two sections when splitting, and cause an exception when there are two many elements to unpack.