### PR TITLE
Allow passing a custom demangler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ python lcov_cobertura.py lcov-file.dat
  - `-b/--base-dir` - (Optional) Directory where source files are located. Defaults to the current directory
  - `-e/--excludes` - (Optional) Comma-separated list of regexes of packages to exclude
  - `-o/--output` - (Optional) Path to store cobertura xml file. _Defaults to ./coverage.xml_
- - `-d/--demangle` - (Optional) Demangle C++ function names. _Requires c++filt_
+ - `-D/--demangler=DEMANGLER` - (Optional) Demangle function names using DEMANGLER
+ - `-d/--demangle` - (Optional) Shortcut for `--demangler=c++filt`
 
 ```bash
 python lcov_cobertura.py lcov-file.dat --base-dir src/dir --excludes test.lib --output build/coverage.xml --demangle
@@ -43,7 +44,8 @@ lcov_cobertura lcov-file.dat
  - `-b/--base-dir` - (Optional) Directory where source files are located. Defaults to the current directory
  - `-e/--excludes` - (Optional) Comma-separated list of regexes of packages to exclude
  - `-o/--output` - (Optional) Path to store cobertura xml file. _Defaults to ./coverage.xml_
- - `-d/--demangle` - (Optional) Demangle C++ function names. _Requires c++filt_
+ - `-D/--demangler=DEMANGLER` - (Optional) Demangle function names using DEMANGLER
+ - `-d/--demangle` - (Optional) Shortcut for `--demangler=c++filt`
 
 ```bash
 lcov_cobertura lcov-file.dat --base-dir src/dir --excludes test.lib --output build/coverage.xml --demangle

--- a/test/mockrustfilt
+++ b/test/mockrustfilt
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import sys
+
+demanglemap = {
+    "_RNvCsie3AuTHCqpB_10rust_hello4calc": "rust_hello::calc",
+    "_RNvCsie3AuTHCqpB_10rust_hello4main": "rust_hello::main",
+}
+
+def main():
+    while True:
+        line = sys.stdin.readline().strip()
+        print(demanglemap[line], flush=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Beyond C++, other language compilers may also mangle names, and need to use a custom demangler. This is done with a new `--demangler` option, defaulting to c++filt when `--demangle` is given. This is compatible with the current CLI, but the API changed a little bit (LcovCobertura takes a string for `demangler` instead of a boolean for `demangle`).