### PR TITLE
Fix when DA-records contains optional checksum

### DIFF
--- a/lcov_cobertura/lcov_cobertura.py
+++ b/lcov_cobertura/lcov_cobertura.py
@@ -168,7 +168,7 @@ class LcovCobertura():
                 file_branches_covered = 0
             elif input_type == 'DA':
                 # DA:2,0
-                (line_number, line_hits) = line_parts[-1].strip().split(',')
+                (line_number, line_hits) = line_parts[-1].strip().split(',')[:2]
                 line_number = int(line_number)
                 if line_number not in file_lines:
                     file_lines[line_number] = {

--- a/test/test_lcov_cobertura.py
+++ b/test/test_lcov_cobertura.py
@@ -40,6 +40,22 @@ class Test(unittest.TestCase):
         self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['methods']['(anonymous_1)'], ['1', '1'])
         self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['methods']['namedFn'], ['2', '0'])
 
+    def test_parse_with_checksum(self):
+        converter = LcovCobertura(
+            'SF:foo/file.ext\nDA:1,1,dummychecksum\nDA:2,0,dummychecksum\nBRDA:1,1,1,1\nBRDA:1,1,2,0\nend_of_record\n')
+        result = converter.parse()
+        self.assertTrue('packages' in result)
+        self.assertTrue('foo' in result['packages'])
+        self.assertEqual(result['packages']['foo']['branches-covered'], 1)
+        self.assertEqual(result['packages']['foo']['branches-total'], 2)
+        self.assertEqual(result['packages']['foo']['branch-rate'], '0.5')
+        self.assertEqual(result['packages']['foo']['line-rate'], '0.5')
+        self.assertEqual(result['packages']['foo']['lines-covered'], 1)
+        self.assertEqual(result['packages']['foo']['lines-total'], 2)
+        self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['branches-covered'], 1)
+        self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['branches-total'], 2)
+        self.assertEqual(result['packages']['foo']['classes']['foo/file.ext']['methods'], {})
+
     def test_exclude_package_from_parser(self):
         converter = LcovCobertura(
             'SF:foo/file.ext\nDA:1,1\nDA:2,0\nend_of_record\nSF:bar/file.ext\nDA:1,1\nDA:2,1\nend_of_record\n',


### PR DESCRIPTION
according to documentation a `DA:....`-record can contain an optional checksum.

currently this breaks `lcov_cobertura`


this should fix it.