### PR TITLE
Fix modulenotfound exception with disutil

### DIFF
--- a/lcov_cobertura/lcov_cobertura.py
+++ b/lcov_cobertura/lcov_cobertura.py
@@ -18,14 +18,14 @@ import subprocess  # nosec - not for untrusted input
 from xml.dom import minidom  # nosec - not for untrusted input
 from optparse import OptionParser
 
-from distutils.spawn import find_executable
+from shutil import which
 
 __version__ = '2.0.2'
 
 CPPFILT = "c++filt"
 HAVE_CPPFILT = False
 
-if find_executable(CPPFILT) is not None:
+if which(CPPFILT) is not None:
     HAVE_CPPFILT = True
 
 


### PR DESCRIPTION
The package distutils is deprecated and slated for removal in Python 3.12. We are using the function find_executable that belongs to that package. We should instead be using which from the package shutil.