### PR TITLE
Fix duplicate C++ ctor/dtor entries with --demangle.

### DIFF
--- a/lcov_cobertura/lcov_cobertura.py
+++ b/lcov_cobertura/lcov_cobertura.py
@@ -205,13 +205,14 @@ class LcovCobertura():
             elif input_type == 'FN':
                 # FN:5,(anonymous_1)
                 function_line, function_name = line_parts[-1].strip().split(',', 1)
-                file_methods[function_name] = [function_line, '0']
+                file_methods[self.format(function_name)] = [function_line, '0']
             elif input_type == 'FNDA':
                 # FNDA:0,(anonymous_1)
                 (function_hits, function_name) = line_parts[-1].strip().split(',', 1)
-                if function_name not in file_methods:
-                    file_methods[function_name] = ['0', '0']
-                file_methods[function_name][-1] = function_hits
+                demangled_fn_name = self.format(function_name)
+                if demangled_fn_name not in file_methods:
+                    file_methods[demangled_fn_name] = ['0', '0']
+                file_methods[demangled_fn_name][-1] += function_hits
 
         # Exclude packages
         excluded = [x for x in coverage_data['packages'] for e in self.excludes
@@ -291,7 +292,7 @@ class LcovCobertura():
                 methods_el = self._el(document, 'methods', {})
                 for method_name, (line, hits) in list(class_data['methods'].items()):
                     method_el = self._el(document, 'method', {
-                        'name': self.format(method_name),
+                        'name': method_name,
                         'signature': '',
                         'line-rate': '1.0' if int(hits) > 0 else '0.0',
                         'branch-rate': '1.0' if int(hits) > 0 else '0.0',


### PR DESCRIPTION
Under certain circumstances, gcc seems to emit multiple symbols for ctors and dtors. This seems to be in adherence with the specification of the Itanium C++ ABI. A pretty good description of the issue can be found [here](https://stackoverflow.com/questions/6921295/dual-emission-of-constructor-symbols) .

However, `c++filt` generates the same demangled names for these symbols. Apparently, [this was not always the case](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35201). Since demangling is currently done _after_ reading the `lcov` files, this results in duplicate entries in the output XML file.

According to [the Cobertura DTD](https://github.com/cobertura/web/blob/master/htdocs/xml/coverage-04.dtd), each `class` should only have a single `method` entry. This can lead to issues with certain parsers. For example, the [Jenkins Coverage](https://plugins.jenkins.io/coverage/) plugin will not accept XML files with duplicate method entries for the same class.

This PR resolves the issue by applying the demangling operation when the function hit data is stored, and summing the hit counts as needed.