### PR TITLE
Fixes FN with 

### DIFF
--- a/lcov_cobertura/lcov_cobertura.py
+++ b/lcov_cobertura/lcov_cobertura.py
@@ -204,7 +204,11 @@ class LcovCobertura():
                 file_branches_covered = int(line_parts[1])
             elif input_type == 'FN':
                 # FN:5,(anonymous_1)
-                function_line, function_name = line_parts[-1].strip().split(',', 1)
+                tokens = line_parts[-1].strip().split(',')
+                if (len(tokens) == 3):
+                  function_line, function_line_ends, function_name = tokens
+                else:
+                  function_line, function_name = tokens
                 file_methods[function_name] = [function_line, '0']
             elif input_type == 'FNDA':
                 # FNDA:0,(anonymous_1)


### PR DESCRIPTION
There are some changes in the lcov version

```
         FN:<line number of function start>,(<line number of function end>,)?<function name>
```

old version

```
         FN:<line number of function start>,<function name>
```

This should fix the issue and don't break user 